### PR TITLE
add index.html to gh-pages to give directory listing

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,22 @@
+<html>
+  <body>
+    <script>
+      (async () => {
+        const repo = window.location.href.split('/').slice(-2).shift()
+        const response = await fetch(`https://api.github.com/repos/stac-extensions/${repo}/git/trees/gh-pages?recursive=true`);
+        const data = await response.json();
+        schemas = data.tree.filter(f => {
+          if (f.path.startsWith('v') && f.path.endsWith('json')) {
+            return true
+          }
+        })
+        let htmlString = `<h1>STAC Extension '${repo}' Schemas</h1><ul>`;
+        for (let s of schemas) {
+          htmlString += `<li><a href="${s.path}">${s.path}</a></li>`;
+        }
+        htmlString += '</ul>';
+        document.getElementsByTagName('body')[0].innerHTML = htmlString;
+      })()
+    </script>
+  <body>
+</html>


### PR DESCRIPTION
This includes a really basic index.html with a snippet of Javascript that generates a listing of all schemas published.

This same approach can be used for https://github.com/radiantearth/stac-spec/issues/983
although it could be made a bit better by indenting schemas by version. Right now it's just a list showing the entire path.

See example here:
https://stac-extensions.github.io/sar/