### PR TITLE
Update template #28, #33, #34

### DIFF
--- a/.github/remark.yaml
+++ b/.github/remark.yaml
@@ -10,7 +10,8 @@ plugins:
 # General formatting
   - - remark-lint-emphasis-marker
     - '*'
-  - remark-lint-no-undefined-references
+  - - remark-lint-no-undefined-references
+    - allow: ['!IMPORTANT', '!WARNING', '!NOTE', '!CAUTION', '!TIP']
   - remark-lint-hard-break-spaces
   - remark-lint-blockquote-indentation
   - remark-lint-no-consecutive-blank-lines
@@ -40,7 +41,7 @@ plugins:
   - - remark-lint-unordered-list-marker-style
     - '-'
   - - remark-lint-list-item-indent
-    - space
+    - one
 # Tables
   - remark-lint-table-pipes
   - remark-lint-no-literal-urls

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -7,10 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Inject env variables
-        uses: rlespinasse/github-slug-action@v4.4.1
-      - uses: actions/checkout@v4
+        uses: rlespinasse/github-slug-action@v5.6.0
+      - uses: actions/checkout@v7
       - name: deploy JSON Schema for version ${{ env.GITHUB_REF_SLUG }}
-        uses: peaceiris/actions-gh-pages@v3.9.3
+        uses: peaceiris/actions-gh-pages@v4.1.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: json-schema

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,10 +4,10 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v6
         with:
           node-version: 'lts/*'
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - run: |
           npm install
           npm test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
@@ -16,4 +17,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-[Unreleased]: <https://github.com/stac-extensions/template/compare/v1.0.0...HEAD>
+[Unreleased]: <https://github.com/stac-extensions/template/compare/v0.1.0...HEAD>

--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 # Template Extension Specification
 
 - **Title:** Template
-- **Identifier:** <https://stac-extensions.github.io/template/v1.0.0/schema.json>
+- **Identifier:** <https://stac-extensions.github.io/template/v0.1.0/schema.json>
 - **Field Name Prefix:** template
-- **Scope:** Item, Collection
+- **Scope:** Catalog, Collection, Item
 - **Extension [Maturity Classification](https://github.com/radiantearth/stac-spec/tree/master/extensions/README.md#extension-maturity):** Proposal
 - **Owner**: @your-gh-handles @person2
 
 This document explains the Template Extension to the [SpatioTemporal Asset Catalog](https://github.com/radiantearth/stac-spec) (STAC) specification.
+
 This is the place to add a short introduction.
 
 - Examples:
@@ -20,11 +21,12 @@ This is the place to add a short introduction.
 
 The fields in the table below can be used in these parts of STAC documents:
 
-- [ ] Catalogs
+- [x] Catalogs
 - [x] Collections
 - [x] Item Properties (incl. Summaries in Collections)
-- [x] Assets (for both Collections and Items, incl. Item Asset Definitions in Collections)
-- [ ] Links
+- [x] Assets (for both Collections and Items, incl. Item Asset Definitions in Collections and Asset Templates)
+- [x] Links (incl. Link Templates)
+- [x] Bands
 
 | Field Name           | Type                      | Description                                  |
 | -------------------- | ------------------------- | -------------------------------------------- |
@@ -67,16 +69,18 @@ for running tests are copied here for convenience.
 
 ### Running tests
 
-The same checks that run as checks on PR's are part of the repository and can be run locally to verify that changes are valid. 
+The same checks that run as checks on PRs are part of the repository and can be run locally to verify that changes are valid.
 To run tests locally, you'll need `npm`, which is a standard part of any [node.js installation](https://nodejs.org/en/download/).
 
-First you'll need to install everything with npm once. Just navigate to the root of this repository and on 
+First you'll need to install everything with npm once. Just navigate to the root of this repository and on
 your command line run:
+
 ```bash
 npm install
 ```
 
 Then to check markdown formatting and test the examples against the JSON schema, you can run:
+
 ```bash
 npm test
 ```
@@ -84,6 +88,7 @@ npm test
 This will spit out the same texts that you see online, and you can then go and fix your markdown or examples.
 
 If the tests reveal formatting problems with the examples, you can fix them with:
+
 ```bash
 npm run format-examples
 ```

--- a/examples/collection.json
+++ b/examples/collection.json
@@ -1,8 +1,7 @@
 {
-  "stac_version": "1.0.0",
+  "stac_version": "1.1.0",
   "stac_extensions": [
-    "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json",
-    "https://stac-extensions.github.io/template/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/template/v0.1.0/schema.json"
   ],
   "type": "Collection",
   "id": "collection",

--- a/examples/item.json
+++ b/examples/item.json
@@ -1,7 +1,7 @@
 {
-  "stac_version": "1.0.0",
+  "stac_version": "1.1.0",
   "stac_extensions": [
-    "https://stac-extensions.github.io/template/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/template/v0.1.0/schema.json"
   ],
   "type": "Feature",
   "id": "item",

--- a/json-schema/schema.json
+++ b/json-schema/schema.json
@@ -1,43 +1,173 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://stac-extensions.github.io/template/v1.0.0/schema.json#",
+  "$id": "https://stac-extensions.github.io/template/v0.1.0/schema.json#",
   "title": "Template Extension",
-  "description": "STAC Template Extension for STAC Items and STAC Collections.",
+  "description": "STAC Template Extension for STAC Catalogs, STAC Collections and STAC Items.",
+  "type": "object",
+  "required": [
+    "stac_extensions",
+    "type"
+  ],
+  "properties": {
+    "stac_extensions": {
+      "type": "array",
+      "contains": {
+        "const": "https://stac-extensions.github.io/template/v0.1.0/schema.json"
+      }
+    },
+    "type": {
+      "$comment": "List the allowed STAC object types here, any of: Catalog, Collection, Feature (for Items)",
+      "type": "string",
+      "enum": [
+        "Catalog",
+        "Collection",
+        "Feature"
+      ]
+    },
+    "assets": {
+      "$comment": "This validates the fields in Item Assets, but does not require them.",
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/fieldsAndBands"
+      }
+    },
+    "links": {
+      "$comment": "This validates the fields in links, remove this if not applicable.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/fields"
+      }
+    },
+    "assetTemplates": {
+      "$comment": "This validates the fields in asset templates, remove this if not applicable.",
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/fieldsAndBands"
+      }
+    },
+    "linkTemplates": {
+      "$comment": "This validates the fields in link templates, remove this if not applicable.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/fields"
+      }
+    }
+  },
   "oneOf": [
     {
-      "$comment": "This is the schema for STAC Items. Remove this object if this extension only applies to Collections.",
+      "$comment": "This validates the fields in the item properties, remove this if not applicable.",
+      "type": "object",
+      "required": ["type", "properties"],
+      "properties": {
+        "type": {
+          "const": "Feature"
+        },
+        "properties": {
+          "$ref": "#/definitions/fieldsAndBands"
+        }
+      }
+    },
+    {
+      "$comment": "This is the schema for top-level fields and item assets in STAC Collections, remove this fully or in parts if not applicable.",
+      "type": "object",
+      "required": ["type"],
+      "properties": {
+        "type": {
+          "const": "Collection"
+        },
+        "summaries": {
+          "$ref": "#/definitions/summaries"
+        },
+        "item_assets": {
+          "$comment": "This validates the fields in item assets, remove this if not applicable.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/fieldsAndBands"
+          }
+        }
+      },
       "allOf": [
         {
-          "$ref": "#/definitions/stac_extensions"
+          "$ref": "#/definitions/fieldsAndBands"
+        }
+      ]
+    },
+    {
+      "$comment": "This is the schema for top-level fields in STAC Catalogs, remove this fully or in parts if not applicable.",
+      "type": "object",
+      "required": ["type"],
+      "properties": {
+        "type": {
+          "const": "Catalog"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/fields"
+        }
+      ]
+    }
+  ],
+  "definitions": {
+    "template:new_field": {
+      "type": "string"
+    },
+    "template:xyz": {
+      "type": "object",
+      "required": [
+        "x",
+        "y",
+        "z"
+      ],
+      "properties": {
+        "x": {
+          "type": "number"
+        },
+        "y": {
+          "type": "number"
+        },
+        "z": {
+          "type": "number"
+        }
+      }
+    },
+    "template:another_one": {
+      "type": "array",
+      "items": {
+        "type": "number"
+      }
+    },
+    "fields": {
+      "$comment": "Add your new fields here. Don't require them here as they would be required in all places where we reference the fields as possibly allowed.",
+      "type": "object",
+      "properties": {
+        "template:new_field": {
+          "$ref": "#/definitions/template:new_field"
+        },
+        "template:xyz": {
+          "$ref": "#/definitions/template:xyz"
+        },
+        "template:another_one": {
+          "$ref": "#/definitions/template:another_one"
+        }
+      },
+      "patternProperties": {
+        "^(?!template:)": {
+          "$comment": "Above, change `template` to the prefix of this extension"
+        }
+      },
+      "additionalProperties": false
+    },
+    "fieldsAndBands": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/fields"
         },
         {
-          "type": "object",
-          "required": [
-            "type",
-            "properties",
-            "assets"
-          ],
           "properties": {
-            "type": {
-              "const": "Feature"
-            },
-            "properties": {
-              "allOf": [
-                {
-                  "$comment": "Require fields here for Item Properties.",
-                  "required": [
-                    "template:new_field"
-                  ]
-                },
-                {
-                  "$ref": "#/definitions/fields"
-                }
-              ]
-            },
-            "assets": {
-              "$comment": "This validates the fields in Item Assets, but does not require them.",
-              "type": "object",
-              "additionalProperties": {
+            "bands": {
+              "type": "array",
+              "items": {
                 "$ref": "#/definitions/fields"
               }
             }
@@ -45,156 +175,34 @@
         }
       ]
     },
-    {
-      "$comment": "This is the schema for STAC Collections.",
-      "type": "object",
-      "allOf": [
-        {
-          "required": [
-            "type"
-          ],
-          "properties": {
-            "type": {
-              "const": "Collection"
-            }
-          }
-        },
-        {
-          "$ref": "#/definitions/stac_extensions"
-        }
-      ],
-      "anyOf": [
-        {
-          "$comment": "This is the schema for the top-level fields in a Collection. Remove this if this extension does not define top-level fields for Collections.",
-          "allOf": [
-            {
-              "$comment": "Require fields here for Collections (top-level).",
-              "required": [
-                "template:new_field"
-              ]
-            },
-            {
-              "$ref": "#/definitions/fields"
-            }
-          ]
-        },
-        {
-          "$comment": "This validates the fields in Collection Assets, but does not require them.",
-          "required": [
-            "assets"
-          ],
-          "properties": {
-            "assets": {
-              "type": "object",
-              "not": {
-                "additionalProperties": {
-                  "not": {
-                    "allOf": [
-                      {
-                        "$ref": "#/definitions/require_any_field"
-                      },
-                      {
-                        "$ref": "#/definitions/fields"
-                      }
-                    ]
-                  }
-                }
-              }
-            }
-          }
-        },
-        {
-          "$comment": "This is the schema for the fields in Item Asset Definitions. It doesn't require any fields.",
-          "required": [
-            "item_assets"
-          ],
-          "properties": {
-            "item_assets": {
-              "type": "object",
-              "not": {
-                "additionalProperties": {
-                  "not": {
-                    "allOf": [
-                      {
-                        "$ref": "#/definitions/require_any_field"
-                      },
-                      {
-                        "$ref": "#/definitions/fields"
-                      }
-                    ]
-                  }
-                }
-              }
-            }
-          }
-        },
-        {
-          "$comment": "This is the schema for the fields in Summaries. By default, only checks the existence of the properties, but not the schema of the summaries.",
-          "required": [
-            "summaries"
-          ],
-          "properties": {
-            "summaries": {
-              "$ref": "#/definitions/require_any_field"
-            }
-          }
-        }
-      ]
-    }
-  ],
-  "definitions": {
-    "stac_extensions": {
-      "type": "object",
-      "required": [
-        "stac_extensions"
-      ],
-      "properties": {
-        "stac_extensions": {
-          "type": "array",
-          "contains": {
-            "const": "https://stac-extensions.github.io/template/v1.0.0/schema.json"
-          }
-        }
-      }
-    },
-    "require_any_field": {
-      "$comment": "Please list all fields here so that we can force the existence of one of them in other parts of the schemas.",
-      "anyOf": [
-        {"required": ["template:new_field"]},
-        {"required": ["template:xyz"]},
-        {"required": ["template:another_one"]}
-      ]
-    },
-    "fields": {
-      "$comment": "Add your new fields here. Don't require them here, do that above in the corresponding schema.",
+    "summaries": {
+      "$comment": "These are examples summaries that allows lists, ranges and JSON schemas, depending on how it makes sense for the individual data types of the fields. Validation only works for lists and ranges. JSON Schema (type: object) can always be provided for fields, but the corresponding schema for lists (type: array and items) and ranges (properties) should only be provided if it actually makes sense.",
       "type": "object",
       "properties": {
         "template:new_field": {
-          "type": "string"
-        },
-        "template:xyz": {
-          "type": "object",
-          "required": [
-            "x",
-            "y",
-            "z"
-          ],
+          "type": ["array", "object"],
+          "items": {
+            "$ref": "#/definitions/template:new_field"
+          },
           "properties": {
-            "x": {
-              "type": "number"
+            "minimum": {
+              "$ref": "#/definitions/template:new_field"
             },
-            "y": {
-              "type": "number"
-            },
-            "z": {
-              "type": "number"
+            "maximum": {
+              "$ref": "#/definitions/template:new_field"
             }
           }
         },
-        "template:another_one": {
-          "type": "array",
+        "template:xyz": {
+          "type": ["array", "object"],
           "items": {
-            "type": "number"
+            "$ref": "#/definitions/template:xyz"
+          }
+        },
+        "template:another_one": {
+          "type": ["array", "object"],
+          "items": {
+            "$ref": "#/definitions/template:another_one"
           }
         }
       },

--- a/package.json
+++ b/package.json
@@ -1,20 +1,20 @@
 {
   "name": "stac-extension-template",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "scripts": {
     "test": "npm run check-markdown && npm run check-examples",
     "check-markdown": "remark . -f -r .github/remark.yaml",
-    "check-examples": "stac-node-validator . --lint --verbose --schemaMap https://stac-extensions.github.io/template/v1.0.0/schema.json=./json-schema/schema.json",
-    "format-examples": "stac-node-validator . --format --schemaMap https://stac-extensions.github.io/template/v1.0.0/schema.json=./json-schema/schema.json"
+    "check-examples": "stac-node-validator . --lint --verbose --schemaMap https://stac-extensions.github.io/template/v0.1.0/schema.json=./json-schema/schema.json",
+    "format-examples": "stac-node-validator . --format --schemaMap https://stac-extensions.github.io/template/v0.1.0/schema.json=./json-schema/schema.json"
   },
   "dependencies": {
     "remark-cli": "^12.0.0",
     "remark-gfm": "^4.0.0",
-    "remark-lint": "^9.1.2",
-    "remark-lint-no-html": "^3.1.2",
-    "remark-preset-lint-consistent": "^5.1.2",
-    "remark-preset-lint-markdown-style-guide": "^5.1.3",
-    "remark-preset-lint-recommended": "^6.1.3",
+    "remark-lint": "^10.0.0",
+    "remark-lint-no-html": "^4.0.0",
+    "remark-preset-lint-consistent": "^6.0.0",
+    "remark-preset-lint-markdown-style-guide": "^6.0.0",
+    "remark-preset-lint-recommended": "^7.0.0",
     "remark-validate-links": "^13.0.0",
     "stac-node-validator": "^1.3.0"
   }


### PR DESCRIPTION
Updated the template repository:

1. Updated dependencies
2. Updated examples to STAC 1.1.0
3. Default version is 0.1.0 instead of 1.0.0
4. Added bands as a field scope #34 
5. Added link and asset templates as options
6. Don't error when we use GitHub note/warning/... blocks
7. Extensive update of the default schema:
   1. Simplifications for the schema where possible and some more comments (we got more functionality with the same schema length)
   2. Add default schemas for bands, catalogs, summaries, links, asset templates and link templates,
   3. Try to enable some basic validation of summaries
   4. Don't check anymore whether any field of the extension exists in the document. This has proven to not work reliably and makes the schema more complex than it needs to be without providing much benefit.
   5. No template for "required fields" as most extensions don't require fields in specific places anyway and it makes the schema more complex than needed. Individual requirements can still be added by users if strictly needed.